### PR TITLE
Point workflow reuse at main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,4 +3,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@keymap-editor
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,3 @@
-# This file generates the GitHub Actions matrix.
 # For simple board + shield combinations, add them to the top level board and
 # shield arrays, for more control, add individual board + shield combinations
 # to the `include` property. You can also use the `cmake-args` property to


### PR DESCRIPTION
- Updated .github/workflows/build.yml to reference @main instead of 
  @keymap-editor.